### PR TITLE
[EliteCore] Migrate Tuple2/Pair

### DIFF
--- a/Advent/Tests/AdventFoundationTests/AdventFoundationTests.swift
+++ b/Advent/Tests/AdventFoundationTests/AdventFoundationTests.swift
@@ -2,12 +2,9 @@
 import XCTest
 
 final class AdventFoundationTests: XCTestCase {
-    func testPairEquality() {
-        let pair = Pair(1, 2)
-        XCTAssertEqual(pair, Pair(1, 2))
-    }
+    func testExample() {}
 
     static var allTests = [
-        ("testPairEquality", testPairEquality),
+        ("testExample", testExample),
     ]
 }

--- a/EliteCore/Package.swift
+++ b/EliteCore/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "EliteCore", targets: ["EliteCore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/nanoxd/Nano", "0.0.2"..."1.0.0")
+        .package(url: "https://github.com/nanoxd/Nano", "0.0.2"..."1.0.0"),
     ],
     targets: [
         .target(name: "EliteCore", dependencies: ["Nano"]),

--- a/EliteCore/README.md
+++ b/EliteCore/README.md
@@ -1,3 +1,5 @@
 # EliteCore
 
-A library containing extensions or abstractions that are helpful in completing challenges. 
+A library containing extensions or abstractions that are helpful in completing challenges. As extensions become more useful, they will be migrated to [Nano][Nano].
+
+[Nano]: https://github.com/nanoxd/Nano

--- a/EliteCore/Sources/EliteCore/Data Structures/Pair.swift
+++ b/EliteCore/Sources/EliteCore/Data Structures/Pair.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// A two-member Tuple of type `T`
+public typealias Pair<T> = Tuple2<T, T>

--- a/EliteCore/Sources/EliteCore/Data Structures/Tuple2.swift
+++ b/EliteCore/Sources/EliteCore/Data Structures/Tuple2.swift
@@ -1,10 +1,14 @@
-public typealias Pair<T> = Tuple2<T, T>
+import Foundation
 
-// MARK: - Tuple2
-
+/// A tuple containing two members of type `A` and `B`
 public struct Tuple2<A, B> {
+    // MARK: - Properties
+
     public let first: A
     public let second: B
+
+    // MARK: - Initializers
+
     public init(_ first: A, _ second: B) {
         self.first = first
         self.second = second

--- a/EliteCore/Tests/EliteCoreTests/Data Structures/Tuple2Tests.swift
+++ b/EliteCore/Tests/EliteCoreTests/Data Structures/Tuple2Tests.swift
@@ -1,0 +1,13 @@
+@testable import EliteCore
+import XCTest
+
+final class Tuple2Tests: XCTestCase {
+    func test_equatable_isEqual() {
+        let pair = Pair(1, 2)
+        XCTAssertEqual(pair, Pair(1, 2))
+    }
+
+    static var allTests = [
+        ("test_equatable_isEqual", test_equatable_isEqual),
+    ]
+}


### PR DESCRIPTION
## ℹ️ Changes

* Migrates Tuple2/Pair to EliteCore
* Updates readme to include context on `Nano`